### PR TITLE
fix signing

### DIFF
--- a/build.js
+++ b/build.js
@@ -28,13 +28,14 @@ esbuild.build({
   bundle: true,
   minify: true,
   sourcemap: false,
-  treeShaking: true,
+  treeShaking: false,
   outdir: './extension',
   legalComments: 'none',
   entryPoints: {
     'App': './src/App.js',
     'nostr-tools': './src/nostr-tools.js'
   },
+  format: 'esm',
 })
 .then(() => console.log('Build success.'))
 .catch((error) => {

--- a/build.js
+++ b/build.js
@@ -28,7 +28,7 @@ esbuild.build({
   bundle: true,
   minify: true,
   sourcemap: false,
-  treeShaking: false,
+  treeShaking: true,
   outdir: './extension',
   legalComments: 'none',
   entryPoints: {

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,22 +1,24 @@
 import * as nostrTools from './nostr-tools.js';
 
 // Use nostrTools as needed
-const { finalizeEvent, verifyEvent, nip04, nip44 } = nostrTools
+const { finalizeEvent, verifyEvent, nip04, nip44, nip19 } = nostrTools
 
 let pubkey = null;
 let seckey = null;
 
 async function signEvent(event) {
+
   try {
-    if (!event) throw new Error('Event object is undefined');
-    // Ensure required fields are present
+	if (!event) throw new Error('Event object is undefined');
+	let { type, data } = nip19.decode(seckey.toString());
+	// Ensure required fields are present
     event.kind = event.kind || 1;
     event.created_at = event.created_at || Math.floor(Date.now() / 1000);
     event.tags = event.tags || [];
     event.content = event.content || '';
     event.pubkey = pubkey;
     // Use finalizeEvent from nostr-tools/pure
-    const finalizedEvent = finalizeEvent(event, seckey);
+    const finalizedEvent = finalizeEvent(event, data);
     return finalizedEvent;
   } catch (error) {
     throw error;

--- a/src/nostr-tools.js
+++ b/src/nostr-tools.js
@@ -1,2 +1,4 @@
-import * as nostrTools from 'nostr-tools'
-export default nostrTools
+import { finalizeEvent, verifyEvent } from 'nostr-tools/pure';
+import { nip04, nip44, nip19 } from 'nostr-tools';
+
+export { finalizeEvent, verifyEvent, nip04, nip44, nip19 };


### PR DESCRIPTION
As per your post:

https://primal.net/e/note1kgafp79h36p0mnsaz47vfahgdts8xrwpufamv0tw3kt7kqqk8vqqq3kr77

This PR fixes the signing problem, tested using Firefox 131.0.2. There were issues with the way esbuild was importing the nostr-tools modules as well as the way the private key was being passed to the finalizeEvent function (as an npub and not hex as specified in nip01). This probably affects the nip-04 and nip-44 functions as well.